### PR TITLE
Added API call to DataLayout. Modified some callers.

### DIFF
--- a/clang/lib/CodeGen/CGAtomic.cpp
+++ b/clang/lib/CodeGen/CGAtomic.cpp
@@ -333,7 +333,7 @@ static RValue emitAtomicLibcall(CodeGenFunction &CGF,
 /// Does a store of the given IR type modify the full expected width?
 static bool isFullSizeType(CodeGenModule &CGM, llvm::Type *type,
                            uint64_t expectedSize) {
-  return (CGM.getDataLayout().getTypeStoreSize(type) * 8 == expectedSize);
+  return (CGM.getDataLayout().getTypeStoreSizeInBits(type) == expectedSize);
 }
 
 /// Does the atomic type require memsetting to zero before initialization?

--- a/clang/lib/CodeGen/ItaniumCXXABI.cpp
+++ b/clang/lib/CodeGen/ItaniumCXXABI.cpp
@@ -2210,7 +2210,7 @@ CGCallee ItaniumCXXABI::getVirtualFunctionPointer(CodeGenFunction &CGF,
 
   llvm::Type *ComponentTy = CGM.getVTables().getVTableComponentType();
   uint64_t ByteOffset =
-      VTableIndex * CGM.getDataLayout().getTypeSizeInBits(ComponentTy) / 8;
+      VTableIndex * CGM.getDataLayout().getTypeSizeInBytes(ComponentTy);
 
   if (!Schema && CGF.ShouldEmitVTableTypeCheckedLoad(MethodDecl->getParent())) {
     VFunc = CGF.EmitVTableTypeCheckedLoad(MethodDecl->getParent(), VTable,

--- a/flang/lib/Optimizer/CodeGen/CodeGen.cpp
+++ b/flang/lib/Optimizer/CodeGen/CodeGen.cpp
@@ -1284,7 +1284,7 @@ genCUFAllocDescriptor(mlir::Location loc,
                                         fctTy);
 
   mlir::Type structTy = typeConverter.convertBoxTypeAsStruct(boxTy);
-  std::size_t boxSize = dl->getTypeSizeInBits(structTy) / 8;
+  std::size_t boxSize = dl->getTypeSizeInBytes(structTy);
   mlir::Value sizeInBytes =
       genConstantIndex(loc, llvmIntPtrType, rewriter, boxSize);
   llvm::SmallVector args = {sizeInBytes, sourceFile, sourceLine};

--- a/flang/lib/Optimizer/Transforms/CUFAddConstructor.cpp
+++ b/flang/lib/Optimizer/Transforms/CUFAddConstructor.cpp
@@ -130,7 +130,7 @@ struct CUFAddConstructor
           if (auto boxTy =
                   mlir::dyn_cast<fir::BaseBoxType>(globalOp.getType())) {
             mlir::Type structTy = typeConverter.convertBoxTypeAsStruct(boxTy);
-            size = dl->getTypeSizeInBits(structTy) / 8;
+            size = dl->getTypeSizeInBytes(structTy);
           }
           if (!size) {
             size = fir::getTypeSizeAndAlignmentOrCrash(loc, globalOp.getType(),

--- a/flang/lib/Optimizer/Transforms/CUFOpConversion.cpp
+++ b/flang/lib/Optimizer/Transforms/CUFOpConversion.cpp
@@ -326,7 +326,7 @@ struct CUFAllocOpConversion : public mlir::OpRewritePattern<cuf::AllocOp> {
         std::size_t size = 0;
         if (fir::isa_derived(seqTy.getEleTy())) {
           mlir::Type structTy = typeConverter->convertType(seqTy.getEleTy());
-          size = dl->getTypeSizeInBits(structTy) / 8;
+          size = dl->getTypeSizeInBytes(structTy);
         } else {
           size = computeWidth(loc, seqTy.getEleTy(), kindMap);
         }
@@ -347,7 +347,7 @@ struct CUFAllocOpConversion : public mlir::OpRewritePattern<cuf::AllocOp> {
         bytes = rewriter.create<mlir::arith::MulIOp>(loc, nbElem, width);
       } else if (fir::isa_derived(op.getInType())) {
         mlir::Type structTy = typeConverter->convertType(op.getInType());
-        std::size_t structSize = dl->getTypeSizeInBits(structTy) / 8;
+        std::size_t structSize = dl->getTypeSizeInBytes(structTy);
         bytes = builder.createIntegerConstant(loc, builder.getIndexType(),
                                               structSize);
       } else {
@@ -379,7 +379,7 @@ struct CUFAllocOpConversion : public mlir::OpRewritePattern<cuf::AllocOp> {
         fir::factory::locationToLineNo(builder, loc, fTy.getInput(2));
 
     mlir::Type structTy = typeConverter->convertBoxTypeAsStruct(boxTy);
-    std::size_t boxSize = dl->getTypeSizeInBits(structTy) / 8;
+    std::size_t boxSize = dl->getTypeSizeInBytes(structTy);
     mlir::Value sizeInBytes =
         builder.createIntegerConstant(loc, builder.getIndexType(), boxSize);
 
@@ -694,7 +694,7 @@ struct CUFDataTransferOpConversion
       if (fir::isa_derived(fir::unwrapSequenceType(dstTy))) {
         mlir::Type structTy =
             typeConverter->convertType(fir::unwrapSequenceType(dstTy));
-        width = dl->getTypeSizeInBits(structTy) / 8;
+        width = dl->getTypeSizeInBytes(structTy);
       } else {
         width = computeWidth(loc, dstTy, kindMap);
       }

--- a/llvm/include/llvm/IR/DataLayout.h
+++ b/llvm/include/llvm/IR/DataLayout.h
@@ -406,6 +406,12 @@ public:
     return getPointerSpec(AS).IndexBitWidth;
   }
 
+  /// The size in bits of the "store" size of the index. This accounts for the
+  /// the fact that ByteWidth * getIndexSize() may be >= getIndexSizeInBits.
+  unsigned getIndexStoreSizeInBits(unsigned AS) const {
+    return getIndexSize(AS) * ByteWidth;
+  }
+
   /// The size in bits of an address in for the given AS. This is defined to
   /// return the same value as getIndexSizeInBits() since there is currently no
   /// target that requires these two properties to have different values. See
@@ -464,6 +470,9 @@ public:
   /// For example, returns 36 for i36 and 80 for x86_fp80. The type passed must
   /// have a size (Type::isSized() must return true).
   TypeSize getTypeSizeInBits(Type *Ty) const;
+
+  /// Equivalent function but scales the size by ByteWidth.
+  TypeSize getTypeSizeInBytes(Type *Ty) const;
 
   /// Returns the maximum number of bytes that may be overwritten by
   /// storing the specified type.
@@ -730,6 +739,11 @@ inline TypeSize DataLayout::getTypeSizeInBits(Type *Ty) const {
   default:
     llvm_unreachable("DataLayout::getTypeSizeInBits(): Unsupported type");
   }
+}
+
+inline TypeSize DataLayout::getTypeSizeInBytes(Type *Ty) const {
+  TypeSize SizeInBits = getTypeSizeInBits(Ty);
+  return {SizeInBits.getKnownMinValue() / ByteWidth, SizeInBits.isScalable()};
 }
 
 } // end namespace llvm

--- a/llvm/lib/CodeGen/GlobalISel/LegalizerHelper.cpp
+++ b/llvm/lib/CodeGen/GlobalISel/LegalizerHelper.cpp
@@ -4771,7 +4771,7 @@ Register LegalizerHelper::getVectorElementPointer(Register VecPtr, LLT VecTy,
   // Convert index to the correct size for the address space.
   const DataLayout &DL = MIRBuilder.getDataLayout();
   unsigned AS = MRI.getType(VecPtr).getAddressSpace();
-  unsigned IndexSizeInBits = DL.getIndexSize(AS) * 8;
+  unsigned IndexSizeInBits = DL.getIndexStoreSizeInBits(AS);
   LLT IdxTy = MRI.getType(Index).changeElementSize(IndexSizeInBits);
   if (IdxTy != MRI.getType(Index))
     Index = MIRBuilder.buildSExtOrTrunc(IdxTy, Index).getReg(0);

--- a/llvm/lib/CodeGen/MachineVerifier.cpp
+++ b/llvm/lib/CodeGen/MachineVerifier.cpp
@@ -1394,7 +1394,7 @@ void MachineVerifier::verifyPreISelGenericInstruction(const MachineInstr *MI) {
     if (PtrTy.isPointerOrPointerVector()) {
       const DataLayout &DL = MF->getDataLayout();
       unsigned AS = PtrTy.getAddressSpace();
-      unsigned IndexSizeInBits = DL.getIndexSize(AS) * 8;
+      unsigned IndexSizeInBits = DL.getIndexStoreSizeInBits(AS);
       if (OffsetTy.getScalarSizeInBits() != IndexSizeInBits) {
         report("gep offset operand must match index size for address space",
                MI);

--- a/llvm/lib/Frontend/HLSL/CBuffer.cpp
+++ b/llvm/lib/Frontend/HLSL/CBuffer.cpp
@@ -65,7 +65,7 @@ void CBufferMetadata::eraseFromModule() {
 
 APInt hlsl::translateCBufArrayOffset(const DataLayout &DL, APInt Offset,
                                      ArrayType *Ty) {
-  int64_t TypeSize = DL.getTypeSizeInBits(Ty->getElementType()) / 8;
+  int64_t TypeSize = DL.getTypeSizeInBytes(Ty->getElementType());
   int64_t RoundUp = alignTo(TypeSize, Align(CBufferRowSizeInBytes));
   return Offset.udiv(TypeSize) * RoundUp;
 }

--- a/llvm/lib/Target/AArch64/AArch64StackTagging.cpp
+++ b/llvm/lib/Target/AArch64/AArch64StackTagging.cpp
@@ -294,7 +294,7 @@ public:
       }
     }
     return IRB.CreateBitOrPointerCast(
-        V, IRB.getIntNTy(DL->getTypeStoreSize(V->getType()) * 8));
+        V, IRB.getIntNTy(DL->getTypeStoreSizeInBits(V->getType())));
   }
 };
 

--- a/llvm/lib/Target/LoongArch/LoongArchISelLowering.cpp
+++ b/llvm/lib/Target/LoongArch/LoongArchISelLowering.cpp
@@ -7267,7 +7267,7 @@ void LoongArchTargetLowering::emitExpandAtomicRMW(AtomicRMWInst *AI) const {
   ShiftAmt = Builder.CreateTrunc(ShiftAmt, WordType, "ShiftAmt");
   Value *Mask = Builder.CreateShl(
       ConstantInt::get(WordType,
-                       (1 << (DL.getTypeStoreSize(ValueType) * 8)) - 1),
+                       (1 << (DL.getTypeStoreSizeInBits(ValueType))) - 1),
       ShiftAmt, "Mask");
   Value *Inv_Mask = Builder.CreateNot(Mask, "Inv_Mask");
   Value *ValOperand_Shifted =

--- a/llvm/lib/Transforms/Scalar/LoopIdiomRecognize.cpp
+++ b/llvm/lib/Transforms/Scalar/LoopIdiomRecognize.cpp
@@ -1205,7 +1205,7 @@ public:
       // Ensure that LoadBasePtr is after StoreBasePtr or before StoreBasePtr
       // for negative stride. LoadBasePtr shouldn't overlap with StoreBasePtr.
       int64_t LoadSize =
-          DL.getTypeSizeInBits(TheLoad.getType()).getFixedValue() / 8;
+          DL.getTypeSizeInBytes(TheLoad.getType()).getFixedValue();
       if (BP1 != BP2 || LoadSize != int64_t(StoreSize))
         return false;
       if ((!IsNegStride && LoadOff < StoreOff + int64_t(StoreSize)) ||

--- a/llvm/lib/Transforms/Scalar/SROA.cpp
+++ b/llvm/lib/Transforms/Scalar/SROA.cpp
@@ -2713,13 +2713,15 @@ public:
                 : nullptr),
         VecTy(PromotableVecTy),
         ElementTy(VecTy ? VecTy->getElementType() : nullptr),
-        ElementSize(VecTy ? DL.getTypeSizeInBits(ElementTy).getFixedValue() / 8
+        ElementSize(VecTy ? DL.getTypeSizeInBytes(ElementTy).getFixedValue()
                           : 0),
         PHIUsers(PHIUsers), SelectUsers(SelectUsers),
         IRB(NewAI.getContext(), ConstantFolder()) {
     if (VecTy) {
-      assert((DL.getTypeSizeInBits(ElementTy).getFixedValue() % 8) == 0 &&
-             "Only multiple-of-8 sized vector elements are viable");
+      auto ByteWidth = DL.getByteWidth();
+      assert(
+          (DL.getTypeSizeInBits(ElementTy).getFixedValue() % ByteWidth) == 0 &&
+          "Only multiple-of-bytewidth sized vector elements are viable");
       ++NumVectorized;
     }
     assert((!IntTy && !VecTy) || (IntTy && !VecTy) || (!IntTy && VecTy));
@@ -3242,7 +3244,7 @@ private:
              "Too many elements!");
 
       Value *Splat = getIntegerSplat(
-          II.getValue(), DL.getTypeSizeInBits(ElementTy).getFixedValue() / 8);
+          II.getValue(), DL.getTypeSizeInBytes(ElementTy).getFixedValue());
       Splat = convertValue(DL, IRB, Splat, ElementTy);
       if (NumElements > 1)
         Splat = getVectorSplat(Splat, NumElements);
@@ -3276,7 +3278,7 @@ private:
       assert(NewEndOffset == NewAllocaEndOffset);
 
       V = getIntegerSplat(II.getValue(),
-                          DL.getTypeSizeInBits(ScalarTy).getFixedValue() / 8);
+                          DL.getTypeSizeInBytes(ScalarTy).getFixedValue());
       if (VectorType *AllocaVecTy = dyn_cast<VectorType>(AllocaTy))
         V = getVectorSplat(
             V, cast<FixedVectorType>(AllocaVecTy)->getNumElements());

--- a/llvm/lib/Transforms/Utils/VNCoercion.cpp
+++ b/llvm/lib/Transforms/Utils/VNCoercion.cpp
@@ -344,9 +344,8 @@ static Value *getStoreValueForLoadHelper(Value *SrcVal, unsigned Offset,
     return SrcVal;
   }
 
-  uint64_t StoreSize =
-      (DL.getTypeSizeInBits(SrcVal->getType()).getFixedValue() + 7) / 8;
-  uint64_t LoadSize = (DL.getTypeSizeInBits(LoadTy).getFixedValue() + 7) / 8;
+  uint64_t StoreSize = DL.getTypeStoreSize(SrcVal->getType()).getFixedValue();
+  uint64_t LoadSize = DL.getTypeStoreSize(LoadTy).getFixedValue();
   // Compute which bits of the stored value are being used by the load.  Convert
   // to an integer type to start with.
   if (SrcVal->getType()->isPtrOrPtrVectorTy())
@@ -409,7 +408,7 @@ Value *getMemInstValueForLoad(MemIntrinsic *SrcInst, unsigned Offset,
                               Type *LoadTy, Instruction *InsertPt,
                               const DataLayout &DL) {
   LLVMContext &Ctx = LoadTy->getContext();
-  uint64_t LoadSize = DL.getTypeSizeInBits(LoadTy).getFixedValue() / 8;
+  uint64_t LoadSize = DL.getTypeSizeInBytes(LoadTy).getFixedValue();
   IRBuilder<> Builder(InsertPt);
 
   // We know that this method is only called when the mem transfer fully
@@ -456,7 +455,8 @@ Value *getMemInstValueForLoad(MemIntrinsic *SrcInst, unsigned Offset,
 Constant *getConstantMemInstValueForLoad(MemIntrinsic *SrcInst, unsigned Offset,
                                          Type *LoadTy, const DataLayout &DL) {
   LLVMContext &Ctx = LoadTy->getContext();
-  uint64_t LoadSize = DL.getTypeSizeInBits(LoadTy).getFixedValue() / 8;
+  // FIXME: Should this be getTypeStoreSize instead?
+  uint64_t LoadSize = DL.getTypeSizeInBytes(LoadTy).getFixedValue();
 
   // We know that this method is only called when the mem transfer fully
   // provides the bits for the load.

--- a/mlir/lib/Conversion/AMDGPUToROCDL/AMDGPUToROCDL.cpp
+++ b/mlir/lib/Conversion/AMDGPUToROCDL/AMDGPUToROCDL.cpp
@@ -189,7 +189,7 @@ struct FatRawBufferCastLowering
 
     DataLayout dataLayout = DataLayout::closest(op);
     int64_t elementByteWidth =
-        dataLayout.getTypeSizeInBits(memrefType.getElementType()) / 8;
+        dataLayout.getTypeSizeInBytes(memrefType.getElementType());
 
     int64_t unusedOffset = 0;
     SmallVector<int64_t, 5> strideVals;
@@ -291,7 +291,7 @@ struct RawBufferOpLowering : public ConvertOpToLLVMPattern<GpuOp> {
     // Get the type size in bytes.
     DataLayout dataLayout = DataLayout::closest(gpuOp);
     int64_t elementByteWidth =
-        dataLayout.getTypeSizeInBits(memrefType.getElementType()) / 8;
+        dataLayout.getTypeSizeInBytes(memrefType.getElementType());
     Value byteWidthConst = createI32Constant(rewriter, loc, elementByteWidth);
 
     // If we want to load a vector<NxT> with total size <= 32


### PR DESCRIPTION
Modified some callers to DataLayout new api calls so that they don't
scale the bitwidths by literal 8, but instead use the appropriate API
to get a value that is already properly scaled by the byte width.
