### PR TITLE
Replaces a number of divide by 8s by divide by ByteWidth

### DIFF
--- a/clang/lib/CodeGen/CGAtomic.cpp
+++ b/clang/lib/CodeGen/CGAtomic.cpp
@@ -1393,6 +1393,7 @@ Address AtomicInfo::castToAtomicIntPointer(Address addr) const {
 Address AtomicInfo::convertToAtomicIntPointer(Address Addr) const {
   llvm::Type *Ty = Addr.getElementType();
   uint64_t SourceSizeInBits = CGF.CGM.getDataLayout().getTypeSizeInBits(Ty);
+  auto ByteWidth = CGF.CGM.getDataLayout().getByteWidth();
   if (SourceSizeInBits != AtomicSizeInBits) {
     Address Tmp = CreateTempAlloca();
     CGF.Builder.CreateMemCpy(Tmp, Addr,

--- a/llvm/include/llvm/CodeGen/TargetLowering.h
+++ b/llvm/include/llvm/CodeGen/TargetLowering.h
@@ -2183,6 +2183,10 @@ public:
     return MaxAtomicSizeInBitsSupported;
   }
 
+  /// Returns the maximum atomic operation size in bytes supported by the
+  /// backend.
+  unsigned getMaxAtomicSizeInBytesSupported() const;
+
   /// Returns the size in bits of the maximum div/rem the backend supports.
   /// Larger operations will be expanded by ExpandLargeDivRem.
   unsigned getMaxDivRemBitWidthSupported() const {
@@ -2203,6 +2207,10 @@ public:
   /// are still natively supported below the minimum; they just
   /// require a more complex expansion.
   unsigned getMinCmpXchgSizeInBits() const { return MinCmpXchgSizeInBits; }
+
+  /// Returns the size in bytes of the smallest cmpxchg or ll/sc/instruction
+  /// the backend supports.
+  unsigned getMinCmpXchgSizeInBytes() const;
 
   /// Whether the target supports unaligned atomic operations.
   bool supportsUnalignedAtomics() const { return SupportsUnalignedAtomics; }

--- a/llvm/include/llvm/IR/Type.h
+++ b/llvm/include/llvm/IR/Type.h
@@ -465,6 +465,7 @@ public:
   LLVM_ABI static IntegerType *getInt32Ty(LLVMContext &C);
   LLVM_ABI static IntegerType *getInt64Ty(LLVMContext &C);
   LLVM_ABI static IntegerType *getInt128Ty(LLVMContext &C);
+  // TODO(torerik): Delete this?? It doesn't make sense.
   template <typename ScalarTy> static Type *getScalarTy(LLVMContext &C) {
     int noOfBits = sizeof(ScalarTy) * CHAR_BIT;
     if (std::is_integral<ScalarTy>::value) {

--- a/llvm/lib/CodeGen/GlobalISel/LegalizerHelper.cpp
+++ b/llvm/lib/CodeGen/GlobalISel/LegalizerHelper.cpp
@@ -4077,10 +4077,12 @@ LegalizerHelper::LegalizeResult LegalizerHelper::lowerLoad(GAnyLoad &LoadMI) {
     return reduceLoadStoreWidth(LoadMI, 0, DstTy.getElementType());
   }
 
+  auto ByteWidth = MIRBuilder.getDataLayout().getByteWidth();
   MachineMemOperand *LargeMMO =
-      MF.getMachineMemOperand(&MMO, 0, LargeSplitSize / 8);
+      MF.getMachineMemOperand(&MMO, 0, LargeSplitSize / ByteWidth);
   MachineMemOperand *SmallMMO =
-      MF.getMachineMemOperand(&MMO, LargeSplitSize / 8, SmallSplitSize / 8);
+      MF.getMachineMemOperand(&MMO, LargeSplitSize / ByteWidth,
+                              SmallSplitSize / ByteWidth);
 
   LLT PtrTy = MRI.getType(PtrReg);
   unsigned AnyExtSize = PowerOf2Ceil(DstTy.getSizeInBits());
@@ -4089,7 +4091,7 @@ LegalizerHelper::LegalizeResult LegalizerHelper::lowerLoad(GAnyLoad &LoadMI) {
                                              PtrReg, *LargeMMO);
 
   auto OffsetCst = MIRBuilder.buildConstant(LLT::scalar(PtrTy.getSizeInBits()),
-                                            LargeSplitSize / 8);
+                                            LargeSplitSize / ByteWidth);
   Register PtrAddReg = MRI.createGenericVirtualRegister(PtrTy);
   auto SmallPtr = MIRBuilder.buildPtrAdd(PtrAddReg, PtrReg, OffsetCst);
   auto SmallLoad = MIRBuilder.buildLoadInstr(LoadMI.getOpcode(), AnyExtTy,
@@ -4194,17 +4196,19 @@ LegalizerHelper::LegalizeResult LegalizerHelper::lowerStore(GStore &StoreMI) {
   auto ShiftAmt = MIRBuilder.buildConstant(NewSrcTy, LargeSplitSize);
   auto SmallVal = MIRBuilder.buildLShr(NewSrcTy, ExtVal, ShiftAmt);
 
+  auto ByteWidth = MIRBuilder.getDataLayout().getByteWidth();
   // Generate the PtrAdd and truncating stores.
   LLT PtrTy = MRI.getType(PtrReg);
   auto OffsetCst = MIRBuilder.buildConstant(
-    LLT::scalar(PtrTy.getSizeInBits()), LargeSplitSize / 8);
+    LLT::scalar(PtrTy.getSizeInBits()), LargeSplitSize / ByteWidth);
   auto SmallPtr =
     MIRBuilder.buildPtrAdd(PtrTy, PtrReg, OffsetCst);
 
   MachineMemOperand *LargeMMO =
-    MF.getMachineMemOperand(&MMO, 0, LargeSplitSize / 8);
+    MF.getMachineMemOperand(&MMO, 0, LargeSplitSize / ByteWidth);
   MachineMemOperand *SmallMMO =
-    MF.getMachineMemOperand(&MMO, LargeSplitSize / 8, SmallSplitSize / 8);
+    MF.getMachineMemOperand(&MMO, LargeSplitSize / ByteWidth, 
+                            SmallSplitSize / ByteWidth);
   MIRBuilder.buildStore(ExtVal, PtrReg, *LargeMMO);
   MIRBuilder.buildStore(SmallVal, SmallPtr, *SmallMMO);
   StoreMI.eraseFromParent();
@@ -4761,8 +4765,9 @@ Register LegalizerHelper::getVectorElementPointer(Register VecPtr, LLT VecTy,
                                                   Register Index) {
   LLT EltTy = VecTy.getElementType();
 
+  auto ByteWidth = MIRBuilder.getDataLayout().getByteWidth();
   // Calculate the element offset and add it to the pointer.
-  unsigned EltSize = EltTy.getSizeInBits() / 8; // FIXME: should be ABI size.
+  unsigned EltSize = EltTy.getSizeInBits() / ByteWidth; // FIXME: should be ABI size.
   assert(EltSize * 8 == EltTy.getSizeInBits() &&
          "Converting bits to bytes lost precision");
 
@@ -5261,13 +5266,15 @@ LegalizerHelper::reduceLoadStoreWidth(GLoadStore &LdStMI, unsigned TypeIdx,
   // handled.
   bool isBigEndian = MIRBuilder.getDataLayout().isBigEndian();
   auto MMO = LdStMI.getMMO();
+
+  auto ByteWidth = MIRBuilder.getDataLayout().getByteWidth();
   auto splitTypePieces = [=](LLT PartTy, SmallVectorImpl<Register> &ValRegs,
                              unsigned NumParts, unsigned Offset) -> unsigned {
     MachineFunction &MF = MIRBuilder.getMF();
     unsigned PartSize = PartTy.getSizeInBits();
     for (unsigned Idx = 0, E = NumParts; Idx != E && Offset < TotalSize;
          ++Idx) {
-      unsigned ByteOffset = Offset / 8;
+      unsigned ByteOffset = Offset / ByteWidth;
       Register NewAddrReg;
 
       MIRBuilder.materializePtrAdd(NewAddrReg, AddrReg, OffsetTy, ByteOffset);
@@ -8968,7 +8975,8 @@ LegalizerHelper::lowerShlSat(MachineInstr &MI) {
 LegalizerHelper::LegalizeResult LegalizerHelper::lowerBswap(MachineInstr &MI) {
   auto [Dst, Src] = MI.getFirst2Regs();
   const LLT Ty = MRI.getType(Src);
-  unsigned SizeInBytes = (Ty.getScalarSizeInBits() + 7) / 8;
+  auto ByteWidth = MIRBuilder.getDataLayout().getByteWidth();
+  unsigned SizeInBytes = divideCeil(Ty.getScalarSizeInBits(), ByteWidth);
   unsigned BaseShiftAmt = (SizeInBytes - 1) * 8;
 
   // Swap most and least significant byte, set remaining bytes in Res to zero.
@@ -9016,15 +9024,16 @@ LegalizerHelper::lowerBitreverse(MachineInstr &MI) {
   unsigned Size = SrcTy.getScalarSizeInBits();
   unsigned VSize = SrcTy.getSizeInBits();
 
-  if (Size >= 8) {
+  auto ByteWidth = MIRBuilder.getDataLayout().getByteWidth();
+  if (Size >= ByteWidth) {
     if (SrcTy.isVector() && (VSize % 8 == 0) &&
         (LI.isLegal({TargetOpcode::G_BITREVERSE,
-                     {LLT::fixed_vector(VSize / 8, 8),
-                      LLT::fixed_vector(VSize / 8, 8)}}))) {
+                     {LLT::fixed_vector(VSize / ByteWidth, ByteWidth),
+                      LLT::fixed_vector(VSize / ByteWidth, ByteWidth)}}))) {
       // If bitreverse is legal for i8 vector of the same size, then cast
       // to i8 vector type.
       // e.g. v4s32 -> v16s8
-      LLT VTy = LLT::fixed_vector(VSize / 8, 8);
+      LLT VTy = LLT::fixed_vector(VSize / ByteWidth, ByteWidth);
       auto BSWAP = MIRBuilder.buildBSwap(SrcTy, Src);
       auto Cast = MIRBuilder.buildBitcast(VTy, BSWAP);
       auto RBIT = MIRBuilder.buildBitReverse(VTy, Cast);

--- a/llvm/lib/CodeGen/SelectionDAG/DAGCombiner.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/DAGCombiner.cpp
@@ -9056,7 +9056,7 @@ calculateByteProvider(unsigned DLByteWidth, SDValue Op, unsigned Index,
     unsigned NarrowBitWidth = NarrowOp.getScalarValueSizeInBits();
     if (NarrowBitWidth % DLByteWidth != 0)
       return std::nullopt;
-    uint64_t NarrowByteWidth = NarrowBitWidth / 8;
+    uint64_t NarrowByteWidth = NarrowBitWidth / DLByteWidth;
     // EXTRACT_VECTOR_ELT can extend the element type to the width of the return
     // type, leaving the high bits undefined.
     if (Index >= NarrowByteWidth)
@@ -9310,11 +9310,11 @@ SDValue DAGCombiner::mergeTruncStores(StoreSDNode *N) {
   auto checkOffsets = [&](bool MatchLittleEndian) {
     if (MatchLittleEndian) {
       for (unsigned i = 0; i != NumStores; ++i)
-        if (OffsetMap[i] != i * (NarrowNumBits / 8) + FirstOffset)
+        if (OffsetMap[i] != i * (NarrowNumBits / DLByteWidth) + FirstOffset)
           return false;
     } else { // MatchBigEndian by reversing loop counter.
       for (unsigned i = 0, j = NumStores - 1; i != NumStores; ++i, --j)
-        if (OffsetMap[j] != i * (NarrowNumBits / 8) + FirstOffset)
+        if (OffsetMap[j] != i * (NarrowNumBits / DLByteWidth) + FirstOffset)
           return false;
     }
     return true;
@@ -9398,7 +9398,7 @@ SDValue DAGCombiner::MatchLoadCombine(SDNode *N) {
   EVT VT = N->getValueType(0);
   if (VT != MVT::i16 && VT != MVT::i32 && VT != MVT::i64)
     return SDValue();
-  unsigned ByteWidth = VT.getSizeInBits() / 8;
+  unsigned ByteWidth = VT.getSizeInBits() / DLByteWidth;
 
   bool IsBigEndianTarget = DAG.getDataLayout().isBigEndian();
   auto MemoryByteOffset = [&](SDByteProvider P) {
@@ -9465,7 +9465,8 @@ SDValue DAGCombiner::MatchLoadCombine(SDNode *N) {
       unsigned LoadWidthInBit = L->getMemoryVT().getScalarSizeInBits();
       if (LoadWidthInBit % DLByteWidth != 0)
         return SDValue();
-      unsigned ByteOffsetFromVector = P->SrcOffset * LoadWidthInBit / 8;
+      unsigned ByteOffsetFromVector = 
+          P->SrcOffset * LoadWidthInBit / DLByteWidth;
       Ptr.addToOffset(ByteOffsetFromVector);
     }
 
@@ -15179,7 +15180,7 @@ SDValue DAGCombiner::reduceLoadWidth(SDNode *N) {
   unsigned PtrAdjustmentInBits =
       DAG.getDataLayout().isBigEndian() ? AdjustBigEndianShift(ShAmt) : ShAmt;
 
-  uint64_t PtrOff = PtrAdjustmentInBits / 8;
+  uint64_t PtrOff = PtrAdjustmentInBits / DLByteWidth;
   SDLoc DL(LN0);
   // The original load itself didn't wrap, so an offset within it doesn't.
   SDValue NewPtr =
@@ -20762,7 +20763,7 @@ SDValue DAGCombiner::ReduceLoadOpStoreWidth(SDNode *N) {
       unsigned PtrAdjustmentInBits = DAG.getDataLayout().isBigEndian()
                                          ? VTStoreSize - NewBW - ShAmt
                                          : ShAmt;
-      PtrOff = PtrAdjustmentInBits / 8;
+      PtrOff = PtrAdjustmentInBits / DLByteWidth;
 
       // Now check if narrow access is allowed and fast, considering alignments.
       unsigned IsFast = 0;
@@ -22225,7 +22226,8 @@ SDValue DAGCombiner::replaceStoreOfInsertLoad(StoreSDNode *ST) {
   // info
   SDValue NewPtr;
   if (auto *CIdx = dyn_cast<ConstantSDNode>(Idx)) {
-    unsigned COffset = CIdx->getSExtValue() * EltVT.getSizeInBits() / 8;
+    unsigned COffset = 
+        CIdx->getSExtValue() * EltVT.getSizeInBits() / DLByteWidth;
     NewPtr = DAG.getMemBasePlusOffset(Ptr, TypeSize::getFixed(COffset), DL);
     PointerInfo = ST->getPointerInfo().getWithOffset(COffset);
   } else {
@@ -22644,10 +22646,13 @@ SDValue DAGCombiner::splitMergedValStore(StoreSDNode *ST) {
   SDValue St0 = DAG.getStore(Chain, DL, Lo, Ptr, ST->getPointerInfo(),
                              ST->getBaseAlign(), MMOFlags, AAInfo);
   Ptr =
-      DAG.getMemBasePlusOffset(Ptr, TypeSize::getFixed(HalfValBitSize / 8), DL);
+      DAG.getMemBasePlusOffset(Ptr, 
+                               TypeSize::getFixed(HalfValBitSize / DLByteWidth),
+                               DL);
   // Higher value store.
-  SDValue St1 = DAG.getStore(
-      St0, DL, Hi, Ptr, ST->getPointerInfo().getWithOffset(HalfValBitSize / 8),
+  SDValue St1 = DAG.getStore(St0, DL, Hi, Ptr, 
+                             ST->getPointerInfo()
+                               .getWithOffset(HalfValBitSize / DLByteWidth),
       ST->getBaseAlign(), MMOFlags, AAInfo);
   return St1;
 }
@@ -22867,18 +22872,19 @@ SDValue DAGCombiner::combineInsertEltToLoad(SDNode *N, unsigned InsIndex) {
   // Check that the offset between the pointers to produce a single continuous
   // load.
   if (InsIndex == 0) {
-    if (!DAG.areNonVolatileConsecutiveLoads(ScalarLoad, VecLoad, EltSize / 8,
-                                            -1))
+    if (!DAG.areNonVolatileConsecutiveLoads(ScalarLoad, VecLoad, 
+                                            EltSize / DLByteWidth, -1))
       return SDValue();
   } else {
     if (!DAG.areNonVolatileConsecutiveLoads(
-            VecLoad, ScalarLoad, VT.getVectorNumElements() * EltSize / 8, -1))
+            VecLoad, ScalarLoad, 
+            VT.getVectorNumElements() * EltSize / DLByteWidth, -1))
       return SDValue();
   }
 
   // And that the new unaligned load will be fast.
   unsigned IsFast = 0;
-  Align NewAlign = commonAlignment(VecLoad->getAlign(), EltSize / 8);
+  Align NewAlign = commonAlignment(VecLoad->getAlign(), EltSize / DLByteWidth);
   if (!TLI.allowsMemoryAccess(*DAG.getContext(), DAG.getDataLayout(),
                               Vec.getValueType(), VecLoad->getAddressSpace(),
                               NewAlign, VecLoad->getMemOperand()->getFlags(),
@@ -22891,10 +22897,12 @@ SDValue DAGCombiner::combineInsertEltToLoad(SDNode *N, unsigned InsIndex) {
   SDValue Ptr = ScalarLoad->getBasePtr();
   if (InsIndex != 0)
     Ptr = DAG.getNode(ISD::ADD, DL, Ptr.getValueType(), VecLoad->getBasePtr(),
-                      DAG.getConstant(EltSize / 8, DL, Ptr.getValueType()));
+                      DAG.getConstant(EltSize / DLByteWidth, DL, 
+                      Ptr.getValueType()));
   MachinePointerInfo PtrInfo =
       InsIndex == 0 ? ScalarLoad->getPointerInfo()
-                    : VecLoad->getPointerInfo().getWithOffset(EltSize / 8);
+                    : VecLoad->getPointerInfo()
+                             .getWithOffset(EltSize / DLByteWidth);
 
   SDValue Load = DAG.getLoad(VecLoad->getValueType(0), DL,
                              ScalarLoad->getChain(), Ptr, PtrInfo, NewAlign);
@@ -29481,7 +29489,8 @@ bool DAGCombiner::parallelizeChainedStores(StoreSDNode *St) {
     return false;
 
   // Add ST's interval.
-  Intervals.insert(0, (St->getMemoryVT().getSizeInBits() + 7) / 8,
+  Intervals.insert(0, divideCeil(St->getMemoryVT().getSizeInBits(),
+                                  DLByteWidth),
                    std::monostate{});
 
   while (StoreSDNode *Chain = dyn_cast<StoreSDNode>(STChain->getChain())) {
@@ -29501,7 +29510,8 @@ bool DAGCombiner::parallelizeChainedStores(StoreSDNode *St) {
     int64_t Offset;
     if (!BasePtr.equalBaseIndex(Ptr, DAG, Offset))
       break;
-    int64_t Length = (Chain->getMemoryVT().getSizeInBits() + 7) / 8;
+    int64_t Length = divideCeil(Chain->getMemoryVT().getSizeInBits(),
+                                DLByteWidth);
     // Make sure we don't overlap with other intervals by checking the ones to
     // the left or right before inserting.
     auto I = Intervals.find(Offset);

--- a/llvm/lib/CodeGen/SelectionDAG/LegalizeDAG.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/LegalizeDAG.cpp
@@ -574,7 +574,7 @@ void SelectionDAGLegalize::LegalizeStoreOps(SDNode *Node) {
                              RoundVT, ST->getBaseAlign(), MMOFlags, AAInfo);
 
       // Store the remaining ExtraWidth bits.
-      IncrementSize = RoundWidth / 8;
+      IncrementSize = RoundWidth / DL.getByteWidth();
       Ptr =
           DAG.getMemBasePlusOffset(Ptr, TypeSize::getFixed(IncrementSize), dl);
       Hi = DAG.getNode(
@@ -596,7 +596,7 @@ void SelectionDAGLegalize::LegalizeStoreOps(SDNode *Node) {
                              ST->getBaseAlign(), MMOFlags, AAInfo);
 
       // Store the remaining ExtraWidth bits.
-      IncrementSize = RoundWidth / 8;
+      IncrementSize = RoundWidth / DL.getByteWidth();
       Ptr = DAG.getNode(ISD::ADD, dl, Ptr.getValueType(), Ptr,
                         DAG.getConstant(IncrementSize, dl,
                                         Ptr.getValueType()));
@@ -795,7 +795,7 @@ void SelectionDAGLegalize::LegalizeLoadOps(SDNode *Node) {
                           MMOFlags, AAInfo);
 
       // Load the remaining ExtraWidth bits.
-      IncrementSize = RoundWidth / 8;
+      IncrementSize = RoundWidth / DL.getByteWidth();
       Ptr =
           DAG.getMemBasePlusOffset(Ptr, TypeSize::getFixed(IncrementSize), dl);
       Hi = DAG.getExtLoad(ExtType, dl, Node->getValueType(0), Chain, Ptr,
@@ -824,7 +824,7 @@ void SelectionDAGLegalize::LegalizeLoadOps(SDNode *Node) {
                           MMOFlags, AAInfo);
 
       // Load the remaining ExtraWidth bits.
-      IncrementSize = RoundWidth / 8;
+      IncrementSize = RoundWidth / DL.getByteWidth();
       Ptr =
           DAG.getMemBasePlusOffset(Ptr, TypeSize::getFixed(IncrementSize), dl);
       Lo = DAG.getExtLoad(ISD::ZEXTLOAD, dl, Node->getValueType(0), Chain, Ptr,
@@ -1583,7 +1583,8 @@ SDValue SelectionDAGLegalize::ExpandVectorBuildThroughStack(SDNode* Node) {
 
   // Emit a store of each element to the stack slot.
   SmallVector<SDValue, 8> Stores;
-  unsigned TypeByteSize = MemVT.getSizeInBits() / 8;
+  unsigned TypeByteSize = MemVT.getSizeInBits() / 
+                          TM.createDataLayout().getByteWidth();
   assert(TypeByteSize > 0 && "Vector element type too small for stack store!");
 
   // If the destination vector element type of a BUILD_VECTOR is narrower than
@@ -1659,7 +1660,7 @@ void SelectionDAGLegalize::getSignAsIntValue(FloatSignAsInt &State,
     State.IntPointerInfo = State.FloatPointerInfo;
   } else {
     // Advance the pointer so that the loaded byte will contain the sign bit.
-    unsigned ByteOffset = (NumBits / 8) - 1;
+    unsigned ByteOffset = (NumBits / DataLayout.getByteWidth()) - 1;
     IntPtr =
         DAG.getMemBasePlusOffset(StackPtr, TypeSize::getFixed(ByteOffset), DL);
     State.IntPointerInfo = MachinePointerInfo::getFixedStack(MF, FI,

--- a/llvm/lib/CodeGen/SelectionDAG/LegalizeIntegerTypes.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/LegalizeIntegerTypes.cpp
@@ -4801,7 +4801,7 @@ void DAGTypeLegalizer::ExpandIntRes_ShiftThroughStack(SDNode *N, SDValue &Lo,
 
   unsigned VTBitWidth = VT.getScalarSizeInBits();
   assert(VTBitWidth % 8 == 0 && "Shifting a not byte multiple value?");
-  unsigned VTByteWidth = VTBitWidth / 8;
+  unsigned VTByteWidth = VTBitWidth / DAG.getDataLayout().getByteWidth();
   assert(isPowerOf2_32(VTByteWidth) &&
          "Shiftee type size is not a power of two!");
   unsigned StackSlotByteWidth = 2 * VTByteWidth;

--- a/llvm/lib/CodeGen/SelectionDAG/LegalizeTypesGeneric.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/LegalizeTypesGeneric.cpp
@@ -174,7 +174,8 @@ void DAGTypeLegalizer::ExpandRes_BITCAST(SDNode *N, SDValue &Lo, SDValue &Hi) {
   Lo = DAG.getLoad(NOutVT, dl, Store, StackPtr, PtrInfo, NOutAlign);
 
   // Increment the pointer to the other half.
-  unsigned IncrementSize = NOutVT.getSizeInBits() / 8;
+  unsigned IncrementSize = NOutVT.getSizeInBits() /
+                           DAG.getDataLayout().getByteWidth();
   StackPtr =
       DAG.getMemBasePlusOffset(StackPtr, TypeSize::getFixed(IncrementSize), dl);
 
@@ -263,7 +264,8 @@ void DAGTypeLegalizer::ExpandRes_NormalLoad(SDNode *N, SDValue &Lo,
                    LD->getBaseAlign(), LD->getMemOperand()->getFlags(), AAInfo);
 
   // Increment the pointer to the other half.
-  unsigned IncrementSize = NVT.getSizeInBits() / 8;
+  unsigned IncrementSize = NVT.getSizeInBits() /
+                           DAG.getDataLayout().getByteWidth();
   Ptr = DAG.getObjectPtrOffset(dl, Ptr, TypeSize::getFixed(IncrementSize));
   Hi = DAG.getLoad(NVT, dl, Chain, Ptr,
                    LD->getPointerInfo().getWithOffset(IncrementSize),
@@ -486,7 +488,8 @@ SDValue DAGTypeLegalizer::ExpandOp_NormalStore(SDNode *N, unsigned OpNo) {
   AAMDNodes AAInfo = St->getAAInfo();
 
   assert(NVT.isByteSized() && "Expanded type not byte sized!");
-  unsigned IncrementSize = NVT.getSizeInBits() / 8;
+  unsigned IncrementSize = NVT.getSizeInBits() /
+                           DAG.getDataLayout().getByteWidth();
 
   SDValue Lo, Hi;
   GetExpandedOp(St->getValue(), Lo, Hi);

--- a/llvm/lib/CodeGen/SelectionDAG/SelectionDAG.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/SelectionDAG.cpp
@@ -8140,7 +8140,7 @@ static SDValue getMemsetStringVal(EVT VT, const SDLoc &dl, SelectionDAG &DAG,
 
   assert(!VT.isVector() && "Can't handle vector type here!");
   unsigned NumVTBits = VT.getSizeInBits();
-  unsigned NumVTBytes = NumVTBits / 8;
+  unsigned NumVTBytes = NumVTBits / DAG.getDataLayout().getByteWidth();
   unsigned NumBytes = std::min(NumVTBytes, unsigned(Slice.Length));
 
   APInt Val(NumVTBits, 0);
@@ -8322,7 +8322,7 @@ static SDValue getMemcpyLoadsAndStores(
   uint64_t SrcOff = 0, DstOff = 0;
   for (unsigned i = 0; i != NumMemOps; ++i) {
     EVT VT = MemOps[i];
-    unsigned VTSize = VT.getSizeInBits() / 8;
+    unsigned VTSize = VT.getSizeInBits() / DAG.getDataLayout().getByteWidth();
     SDValue Value, Store;
 
     if (VTSize > Size) {
@@ -8512,7 +8512,7 @@ static SDValue getMemmoveLoadsAndStores(SelectionDAG &DAG, const SDLoc &dl,
   unsigned NumMemOps = MemOps.size();
   for (unsigned i = 0; i < NumMemOps; i++) {
     EVT VT = MemOps[i];
-    unsigned VTSize = VT.getSizeInBits() / 8;
+    unsigned VTSize = VT.getSizeInBits() / DAG.getDataLayout().getByteWidth();
     SDValue Value;
 
     bool isDereferenceable =
@@ -8533,7 +8533,7 @@ static SDValue getMemmoveLoadsAndStores(SelectionDAG &DAG, const SDLoc &dl,
   OutChains.clear();
   for (unsigned i = 0; i < NumMemOps; i++) {
     EVT VT = MemOps[i];
-    unsigned VTSize = VT.getSizeInBits() / 8;
+    unsigned VTSize = VT.getSizeInBits() / DAG.getDataLayout().getByteWidth();
     SDValue Store;
 
     Store = DAG.getStore(
@@ -8634,7 +8634,7 @@ static SDValue getMemsetStores(SelectionDAG &DAG, const SDLoc &dl,
 
   for (unsigned i = 0; i < NumMemOps; i++) {
     EVT VT = MemOps[i];
-    unsigned VTSize = VT.getSizeInBits() / 8;
+    unsigned VTSize = VT.getSizeInBits() / DAG.getDataLayout().getByteWidth();
     if (VTSize > Size) {
       // Issuing an unaligned load / store pair  that overlaps with the previous
       // pair. Adjust the offset accordingly.
@@ -8674,7 +8674,7 @@ static SDValue getMemsetStores(SelectionDAG &DAG, const SDLoc &dl,
         isVol ? MachineMemOperand::MOVolatile : MachineMemOperand::MONone,
         NewAAInfo);
     OutChains.push_back(Store);
-    DstOff += VT.getSizeInBits() / 8;
+    DstOff += VT.getSizeInBits() / DAG.getDataLayout().getByteWidth();
     Size -= VTSize;
   }
 
@@ -12959,7 +12959,7 @@ bool SelectionDAG::areNonVolatileConsecutiveLoads(LoadSDNode *LD,
   if (LD->getChain() != Base->getChain())
     return false;
   EVT VT = LD->getMemoryVT();
-  if (VT.getSizeInBits() / 8 != Bytes)
+  if (VT.getSizeInBits() / getDataLayout().getByteWidth() != Bytes)
     return false;
 
   auto BaseLocDecomp = BaseIndexOffset::match(Base, *this);

--- a/llvm/lib/CodeGen/SelectionDAG/SelectionDAGBuilder.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/SelectionDAGBuilder.cpp
@@ -1902,7 +1902,8 @@ SDValue SelectionDAGBuilder::getValueImpl(const Value *V) {
           DAG.getNode(
               ISD::SPLAT_VECTOR, getCurSDLoc(),
               EVT::getVectorVT(*DAG.getContext(), MVT::i8,
-                               VT.getSizeInBits().getKnownMinValue() / 8, true),
+                               VT.getSizeInBits().getKnownMinValue() / 
+                               DAG.getDataLayout().getByteWidth(), true),
               DAG.getConstant(0, getCurSDLoc(), MVT::getIntegerVT(8))));
     }
 
@@ -3018,7 +3019,9 @@ static SDValue getLoadStackGuard(SelectionDAG &DAG, const SDLoc &DL,
     auto Flags = MachineMemOperand::MOLoad | MachineMemOperand::MOInvariant |
                  MachineMemOperand::MODereferenceable;
     MachineMemOperand *MemRef = MF.getMachineMemOperand(
-        MPInfo, Flags, PtrTy.getSizeInBits() / 8, DAG.getEVTAlign(PtrTy));
+        MPInfo, Flags, 
+        PtrTy.getSizeInBits() / DAG.getDataLayout().getByteWidth(),
+        DAG.getEVTAlign(PtrTy));
     DAG.setNodeMemRefs(Node, {MemRef});
   }
   if (PtrTy != PtrMemTy)
@@ -5147,7 +5150,8 @@ void SelectionDAGBuilder::visitAtomicLoad(const LoadInst &I) {
   EVT MemVT = TLI.getMemValueType(DAG.getDataLayout(), I.getType());
 
   if (!TLI.supportsUnalignedAtomics() &&
-      I.getAlign().value() < MemVT.getSizeInBits() / 8)
+      I.getAlign().value() < 
+      MemVT.getSizeInBits() / DAG.getDataLayout().getByteWidth())
     report_fatal_error("Cannot generate unaligned atomic load");
 
   auto Flags = TLI.getLoadMemOperandFlags(I, DAG.getDataLayout(), AC, LibInfo);
@@ -5184,7 +5188,8 @@ void SelectionDAGBuilder::visitAtomicStore(const StoreInst &I) {
       TLI.getMemValueType(DAG.getDataLayout(), I.getValueOperand()->getType());
 
   if (!TLI.supportsUnalignedAtomics() &&
-      I.getAlign().value() < MemVT.getSizeInBits() / 8)
+      I.getAlign().value() < MemVT.getSizeInBits() /
+                             DAG.getDataLayout().getByteWidth())
     report_fatal_error("Cannot generate unaligned atomic store");
 
   auto Flags = TLI.getStoreMemOperandFlags(I, DAG.getDataLayout());
@@ -10942,7 +10947,10 @@ TargetLowering::LowerCallTo(TargetLowering::CallLoweringInfo &CLI) const {
       uint64_t Offset = OldOffsets[i];
       MVT RegisterVT = getRegisterType(CLI.RetTy->getContext(), RetVT);
       unsigned NumRegs = getNumRegisters(CLI.RetTy->getContext(), RetVT);
-      unsigned RegisterVTByteSZ = RegisterVT.getSizeInBits() / 8;
+      unsigned RegisterVTByteSZ = RegisterVT.getSizeInBits() /
+                                  getTargetMachine()
+                                  .createDataLayout()
+                                  .getByteWidth();
       RetTys.append(NumRegs, RegisterVT);
       for (unsigned j = 0; j != NumRegs; ++j)
         Offsets.push_back(TypeSize::getFixed(Offset + j * RegisterVTByteSZ));

--- a/llvm/lib/CodeGen/SelectionDAG/TargetLowering.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/TargetLowering.cpp
@@ -37,6 +37,18 @@
 #include <deque>
 using namespace llvm;
 
+unsigned TargetLoweringBase::getMaxAtomicSizeInBytesSupported() const
+{
+  return divideCeil(getMaxAtomicSizeInBitsSupported(),
+                    getTargetMachine().createDataLayout().getByteWidth());
+}
+
+unsigned TargetLoweringBase::getMinCmpXchgSizeInBytes() const
+{
+  return divideCeil(getMinCmpXchgSizeInBits(),
+                    getTargetMachine().createDataLayout().getByteWidth());
+}
+
 /// NOTE: The TargetMachine owns TLOF.
 TargetLowering::TargetLowering(const TargetMachine &tm)
     : TargetLoweringBase(tm) {}
@@ -213,13 +225,14 @@ bool TargetLowering::findOptimalMemOpLowering(
 
   EVT VT = getOptimalMemOpType(Op, FuncAttributes);
 
+  auto ByteWidth = getTargetMachine().createDataLayout().getByteWidth();
   if (VT == MVT::Other) {
     // Use the largest integer type whose alignment constraints are satisfied.
     // We only need to check DstAlign here as SrcAlign is always greater or
     // equal to DstAlign (or zero).
     VT = MVT::LAST_INTEGER_VALUETYPE;
     if (Op.isFixedDstAlign())
-      while (Op.getDstAlign() < (VT.getSizeInBits() / 8) &&
+      while (Op.getDstAlign() < (VT.getSizeInBits() / ByteWidth) &&
              !allowsMisalignedMemoryAccesses(VT, DstAS, Op.getDstAlign()))
         VT = (MVT::SimpleValueType)(VT.getSimpleVT().SimpleTy - 1);
     assert(VT.isInteger());
@@ -239,7 +252,7 @@ bool TargetLowering::findOptimalMemOpLowering(
   unsigned NumMemOps = 0;
   uint64_t Size = Op.size();
   while (Size) {
-    unsigned VTSize = VT.getSizeInBits() / 8;
+    unsigned VTSize = VT.getSizeInBits() / ByteWidth;
     while (VTSize > Size) {
       // For now, only use non-vector load / store's for the left-over pieces.
       EVT NewVT = VT;
@@ -267,7 +280,7 @@ bool TargetLowering::findOptimalMemOpLowering(
             break;
         } while (!isSafeMemOpType(NewVT.getSimpleVT()));
       }
-      NewVTSize = NewVT.getSizeInBits() / 8;
+      NewVTSize = NewVT.getSizeInBits() / ByteWidth;
 
       // If the new VT cannot cover all of the remaining bits, then consider
       // issuing a (or a pair of) unaligned and overlapping load / store.
@@ -4718,6 +4731,7 @@ SDValue TargetLowering::SimplifySetCC(EVT VT, SDValue N0, SDValue N1,
         isa<LoadSDNode>(N0.getOperand(0)) &&
         N0.getOperand(0).getNode()->hasOneUse() &&
         isa<ConstantSDNode>(N0.getOperand(1))) {
+      auto ByteWidth = getTargetMachine().createDataLayout().getByteWidth();
       auto *Lod = cast<LoadSDNode>(N0.getOperand(0));
       APInt bestMask;
       unsigned bestWidth = 0, bestOffset = 0;
@@ -4746,14 +4760,15 @@ SDValue TargetLowering::SimplifySetCC(EVT VT, SDValue N0, SDValue N1,
                   Layout.isLittleEndian() ? offset : memWidth - width - offset;
               unsigned IsFast = 0;
               assert((ptrOffset % 8) == 0 && "Non-Bytealigned pointer offset");
-              Align NewAlign = commonAlignment(Lod->getAlign(), ptrOffset / 8);
+              Align NewAlign = commonAlignment(Lod->getAlign(),
+                                               ptrOffset / ByteWidth);
               if (shouldReduceLoadWidth(Lod, ISD::NON_EXTLOAD, newVT,
-                                        ptrOffset / 8) &&
+                                        ptrOffset / ByteWidth) &&
                   allowsMemoryAccess(
                       *DAG.getContext(), Layout, newVT, Lod->getAddressSpace(),
                       NewAlign, Lod->getMemOperand()->getFlags(), &IsFast) &&
                   IsFast) {
-                bestOffset = ptrOffset / 8;
+                bestOffset = ptrOffset / ByteWidth;
                 bestMask = Mask.lshr(offset);
                 bestWidth = width;
                 break;
@@ -10037,7 +10052,8 @@ TargetLowering::scalarizeVectorLoad(LoadSDNode *LD,
     return std::make_pair(Value, Load.getValue(1));
   }
 
-  unsigned Stride = SrcEltVT.getSizeInBits() / 8;
+  auto ByteWidth = getTargetMachine().createDataLayout().getByteWidth();
+  unsigned Stride = SrcEltVT.getSizeInBits() / ByteWidth;
   assert(SrcEltVT.isByteSized());
 
   SmallVector<SDValue, 8> Vals;
@@ -10113,7 +10129,8 @@ SDValue TargetLowering::scalarizeVectorStore(StoreSDNode *ST,
   }
 
   // Store Stride in bytes
-  unsigned Stride = MemSclVT.getSizeInBits() / 8;
+  auto ByteWidth = getTargetMachine().createDataLayout().getByteWidth();
+  unsigned Stride = MemSclVT.getSizeInBits() / ByteWidth;
   assert(Stride && "Zero stride!");
   // Extract each of the elements from the original vector and save them into
   // memory individually.
@@ -10146,6 +10163,7 @@ TargetLowering::expandUnalignedLoad(LoadSDNode *LD, SelectionDAG &DAG) const {
   EVT LoadedVT = LD->getMemoryVT();
   SDLoc dl(LD);
   auto &MF = DAG.getMachineFunction();
+  auto ByteWidth = getTargetMachine().createDataLayout().getByteWidth();
 
   if (VT.isFloatingPoint() || VT.isVector()) {
     EVT intVT = EVT::getIntegerVT(*DAG.getContext(), LoadedVT.getSizeInBits());
@@ -10172,7 +10190,7 @@ TargetLowering::expandUnalignedLoad(LoadSDNode *LD, SelectionDAG &DAG) const {
     // loads and stores, then do a (aligned) load from the stack slot.
     MVT RegVT = getRegisterType(*DAG.getContext(), intVT);
     unsigned LoadedBytes = LoadedVT.getStoreSize();
-    unsigned RegBytes = RegVT.getSizeInBits() / 8;
+    unsigned RegBytes = RegVT.getSizeInBits() / ByteWidth;
     unsigned NumRegs = (LoadedBytes + RegBytes - 1) / RegBytes;
 
     // Make sure the stack slot is also aligned for the register type.
@@ -10242,7 +10260,7 @@ TargetLowering::expandUnalignedLoad(LoadSDNode *LD, SelectionDAG &DAG) const {
   NumBits >>= 1;
 
   Align Alignment = LD->getBaseAlign();
-  unsigned IncrementSize = NumBits / 8;
+  unsigned IncrementSize = NumBits / ByteWidth;
   ISD::LoadExtType HiExtType = LD->getExtensionType();
 
   // If the original load is NON_EXTLOAD, the hi part load must be ZEXTLOAD.
@@ -10297,6 +10315,7 @@ SDValue TargetLowering::expandUnalignedStore(StoreSDNode *ST,
   EVT StoreMemVT = ST->getMemoryVT();
 
   SDLoc dl(ST);
+  auto ByteWidth = getTargetMachine().createDataLayout().getByteWidth();
   if (StoreMemVT.isFloatingPoint() || StoreMemVT.isVector()) {
     EVT intVT = EVT::getIntegerVT(*DAG.getContext(), VT.getSizeInBits());
     if (isTypeLegal(intVT)) {
@@ -10321,7 +10340,7 @@ SDValue TargetLowering::expandUnalignedStore(StoreSDNode *ST,
         EVT::getIntegerVT(*DAG.getContext(), StoreMemVT.getSizeInBits()));
     EVT PtrVT = Ptr.getValueType();
     unsigned StoredBytes = StoreMemVT.getStoreSize();
-    unsigned RegBytes = RegVT.getSizeInBits() / 8;
+    unsigned RegBytes = RegVT.getSizeInBits() / ByteWidth;
     unsigned NumRegs = (StoredBytes + RegBytes - 1) / RegBytes;
 
     // Make sure the stack slot is also aligned for the register type.
@@ -10382,7 +10401,7 @@ SDValue TargetLowering::expandUnalignedStore(StoreSDNode *ST,
   // Get the half-size VT
   EVT NewStoredVT = StoreMemVT.getHalfSizedIntegerVT(*DAG.getContext());
   unsigned NumBits = NewStoredVT.getFixedSizeInBits();
-  unsigned IncrementSize = NumBits / 8;
+  unsigned IncrementSize = NumBits / ByteWidth;
 
   // Divide the stored value in two parts.
   SDValue ShiftAmount =
@@ -10442,8 +10461,9 @@ TargetLowering::IncrementMemoryAddress(SDValue Addr, SDValue Mask,
     Increment = DAG.getNode(ISD::CTPOP, DL, MaskIntVT, MaskInIntReg);
     Increment = DAG.getZExtOrTrunc(Increment, DL, AddrVT);
     // Scale is an element size in bytes.
-    SDValue Scale = DAG.getConstant(DataVT.getScalarSizeInBits() / 8, DL,
-                                    AddrVT);
+    auto ByteWidth = getTargetMachine().createDataLayout().getByteWidth();
+    SDValue Scale = DAG.getConstant(DataVT.getScalarSizeInBits() / ByteWidth,
+                                    DL, AddrVT);
     Increment = DAG.getNode(ISD::MUL, DL, AddrVT, Increment, Scale);
   } else if (DataVT.isScalableVector()) {
     Increment = DAG.getVScale(DL, AddrVT,
@@ -10509,7 +10529,8 @@ SDValue TargetLowering::getVectorSubVecPointer(SelectionDAG &DAG,
   EVT EltVT = VecVT.getVectorElementType();
 
   // Calculate the element offset and add it to the pointer.
-  unsigned EltSize = EltVT.getFixedSizeInBits() / 8; // FIXME: should be ABI size.
+  auto ByteWidth = getTargetMachine().createDataLayout().getByteWidth();
+  unsigned EltSize = EltVT.getFixedSizeInBits() / ByteWidth; // FIXME: should be ABI size.
   assert(EltSize * 8 == EltVT.getFixedSizeInBits() &&
          "Converting bits to bytes lost precision");
   assert(SubVecVT.getVectorElementType() == EltVT &&


### PR DESCRIPTION
- **This adds get(Primitive|Scalar)WidthInBytes API calls**
- **This fixes some issues in previous commit.**
- **Replaces a number of divide by 8s by divide by ByteWidth**
