### PR TITLE
Another iteration of removing divide by 8

### DIFF
--- a/clang/include/clang/AST/Type.h
+++ b/clang/include/clang/AST/Type.h
@@ -1914,11 +1914,9 @@ protected:
     unsigned : NumArrayTypeBits;
 
     /// Whether we have a stored size expression.
-    LLVM_PREFERRED_TYPE(bool)
-    unsigned HasExternalSize : 1;
+    bool HasExternalSize;
 
-    LLVM_PREFERRED_TYPE(unsigned)
-    unsigned SizeWidth : 5;
+    uint16_t SizeWidth;
   };
 
   class BuiltinTypeBitfields {
@@ -3702,9 +3700,7 @@ class ConstantArrayType : public ArrayType {
                     ArraySizeModifier SM, unsigned TQ)
       : ArrayType(ConstantArray, Et, Can, SM, TQ, nullptr), Size(Sz) {
     ConstantArrayTypeBits.HasExternalSize = false;
-    ConstantArrayTypeBits.SizeWidth = Width / 8;
-    // The in-structure size stores the size in bytes rather than bits so we
-    // drop the three least significant bits since they're always zero anyways.
+    ConstantArrayTypeBits.SizeWidth = Width;
     assert(Width < 0xFF && "Type width in bits must be less than 8 bits");
   }
 
@@ -3742,14 +3738,14 @@ public:
   llvm::APInt getSize() const {
     return ConstantArrayTypeBits.HasExternalSize
                ? SizePtr->Size
-               : llvm::APInt(ConstantArrayTypeBits.SizeWidth * 8, Size);
+               : llvm::APInt(ConstantArrayTypeBits.SizeWidth, Size);
   }
 
   /// Return the bit width of the size type.
   unsigned getSizeBitWidth() const {
     return ConstantArrayTypeBits.HasExternalSize
                ? SizePtr->Size.getBitWidth()
-               : static_cast<unsigned>(ConstantArrayTypeBits.SizeWidth * 8);
+               : static_cast<unsigned>(ConstantArrayTypeBits.SizeWidth);
   }
 
   /// Return true if the size is zero.

--- a/clang/include/clang/Basic/TargetInfo.h
+++ b/clang/include/clang/Basic/TargetInfo.h
@@ -87,6 +87,7 @@ enum class FloatModeKind {
 /// be copied for targets like AMDGPU that base their ABIs on an auxiliary
 /// CPU target.
 struct TransferrableTargetInfo {
+  unsigned char ByteWidth;
   unsigned char PointerWidth, PointerAlign;
   unsigned char BoolWidth, BoolAlign;
   unsigned char ShortWidth, ShortAlign;
@@ -515,8 +516,10 @@ public:
   /// Return the alignment of '_Bool' and C++ 'bool' for this target.
   unsigned getBoolAlign() const { return BoolAlign; }
 
-  unsigned getCharWidth() const { return 8; } // FIXME
-  unsigned getCharAlign() const { return 8; } // FIXME
+  unsigned getByteWidth() const { return ByteWidth; }
+
+  unsigned getCharWidth() const { return ByteWidth; } // FIXME
+  unsigned getCharAlign() const { return ByteWidth; } // FIXME
 
   /// getShortWidth/Align - Return the size of 'signed short' and
   /// 'unsigned short' for this target, in bits.

--- a/clang/lib/AST/ByteCode/BitcastBuffer.cpp
+++ b/clang/lib/AST/ByteCode/BitcastBuffer.cpp
@@ -24,11 +24,11 @@ void BitcastBuffer::pushData(const std::byte *In, Bits BitOffset, Bits BitWidth,
     if (!BitValue)
       continue;
 
-    Bits DstBit;
+    Bits DstBit(0, FinalBitSize.ByteWidth);
     if (TargetEndianness == Endian::Little)
-      DstBit = BitOffset + Bits(It);
+      DstBit = BitOffset + Bits(It, FinalBitSize.ByteWidth);
     else
-      DstBit = size() - BitOffset - BitWidth + Bits(It);
+      DstBit = size() - BitOffset - BitWidth + Bits(It, FinalBitSize.ByteWidth);
 
     size_t DstByte = DstBit.roundToBytes();
     Data[DstByte] |= std::byte{1} << DstBit.getOffsetInByte();
@@ -43,7 +43,7 @@ BitcastBuffer::copyBits(Bits BitOffset, Bits BitWidth, Bits FullBitWidth,
   auto Out = std::make_unique<std::byte[]>(FullBitWidth.roundToBytes());
 
   for (unsigned It = 0; It != BitWidth.getQuantity(); ++It) {
-    Bits BitIndex;
+    Bits BitIndex(0, FinalBitSize.ByteWidth);
     if (TargetEndianness == Endian::Little)
       BitIndex = BitOffset + Bits(It);
     else
@@ -111,7 +111,7 @@ bool BitcastBuffer::rangeInitialized(Bits Offset, Bits Length) const {
     return true;
 
   BitRange Range(Offset, Offset + Length - Bits(1));
-  Bits Sum;
+  Bits Sum(0, FinalBitSize.ByteWidth);
   bool FoundStart = false;
   for (BitRange BR : InitializedBits) {
     if (FoundStart) {

--- a/clang/lib/AST/ByteCode/InterpBuiltin.cpp
+++ b/clang/lib/AST/ByteCode/InterpBuiltin.cpp
@@ -1808,7 +1808,9 @@ static bool interp__builtin_memcpy(InterpState &S, CodePtr OpPC,
   }
 
   assert(Size.getZExtValue() % DestElemSize == 0);
-  if (!DoMemcpy(S, OpPC, SrcPtr, DestPtr, Bytes(Size.getZExtValue()).toBits()))
+  if (!DoMemcpy(S, OpPC, SrcPtr, DestPtr, 
+                Bytes(Size.getZExtValue(),
+                      ASTCtx.getTargetInfo().getByteWidth()).toBits()))
     return false;
 
   S.Stk.push<Pointer>(DestPtr);
@@ -1861,7 +1863,8 @@ static bool interp__builtin_memcmp(InterpState &S, CodePtr OpPC,
 
   // Now, read both pointers to a buffer and compare those.
   BitcastBuffer BufferA(
-      Bits(ASTCtx.getTypeSize(ElemTypeA) * PtrA.getNumElems()));
+      Bits(ASTCtx.getTypeSize(ElemTypeA) * PtrA.getNumElems(),
+           ASTCtx.getTargetInfo().getByteWidth()));
   readPointerToBuffer(S.getContext(), PtrA, BufferA, false);
   // FIXME: The swapping here is UNDOING something we do when reading the
   // data into the buffer.
@@ -1869,7 +1872,8 @@ static bool interp__builtin_memcmp(InterpState &S, CodePtr OpPC,
     swapBytes(BufferA.Data.get(), BufferA.byteSize().getQuantity());
 
   BitcastBuffer BufferB(
-      Bits(ASTCtx.getTypeSize(ElemTypeB) * PtrB.getNumElems()));
+      Bits(ASTCtx.getTypeSize(ElemTypeB) * PtrB.getNumElems(),
+           ASTCtx.getTargetInfo().getByteWidth()));
   readPointerToBuffer(S.getContext(), PtrB, BufferB, false);
   // FIXME: The swapping here is UNDOING something we do when reading the
   // data into the buffer.

--- a/clang/lib/AST/ByteCode/InterpBuiltinBitCast.cpp
+++ b/clang/lib/AST/ByteCode/InterpBuiltinBitCast.cpp
@@ -379,7 +379,8 @@ bool clang::interp::DoBitCastPtr(InterpState &S, CodePtr OpPC,
     return false;
 
   const ASTContext &ASTCtx = S.getASTContext();
-  BitcastBuffer Buffer(Bytes(Size).toBits());
+  auto ByteWidth = ASTCtx.getTargetInfo().getByteWidth();
+  BitcastBuffer Buffer(Bytes(Size, ByteWidth).toBits());
   readPointerToBuffer(S.getContext(), FromPtr, Buffer,
                       /*ReturnOnUninit=*/false);
 
@@ -407,7 +408,7 @@ bool clang::interp::DoBitCastPtr(InterpState &S, CodePtr OpPC,
           return true;
         }
 
-        Bits BitWidth;
+        Bits BitWidth(0, ByteWidth);
         if (const FieldDecl *FD = P.getField(); FD && FD->isBitField())
           BitWidth = Bits(std::min(FD->getBitWidthValue(),
                                    (unsigned)FullBitWidth.getQuantity()));

--- a/clang/lib/AST/ExprConstant.cpp
+++ b/clang/lib/AST/ExprConstant.cpp
@@ -7553,7 +7553,6 @@ class APValueToBufferConverter {
 
         Res.insertBits(EltAsInt, BigEndian ? (NElts - I - 1) : I);
       }
-
       SmallVector<uint8_t, 8> Bytes(NElts / 8);
       llvm::StoreIntToMemory(Res, &*Bytes.begin(), NElts / 8);
       Buffer.writeObject(Offset, Bytes);

--- a/clang/lib/Basic/TargetInfo.cpp
+++ b/clang/lib/Basic/TargetInfo.cpp
@@ -72,6 +72,7 @@ TargetInfo::TargetInfo(const llvm::Triple &T) : Triple(T) {
   HasLongDouble = true;
   HasFPReturn = true;
   HasStrictFP = false;
+  ByteWidth = 8;
   PointerWidth = PointerAlign = 32;
   BoolWidth = BoolAlign = 8;
   ShortWidth = ShortAlign = 16;


### PR DESCRIPTION
- **This adds get(Primitive|Scalar)WidthInBytes API calls**
- **This fixes some issues in previous commit.**
- **Replaces a number of divide by 8s by divide by ByteWidth**
- **Changed divides to divideCeil**
- **Another iteration of getting rid of divide by 8.**
